### PR TITLE
use config_ac.h for our config.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-module-config.h
-module-config.h.in
+config_ac.h
+config_ac.h.in
 build-aux/*
 .deps/
 .libs/

--- a/configure.ac
+++ b/configure.ac
@@ -3,8 +3,8 @@
 
 AC_PREREQ([2.65])
 AC_INIT([pulseaudio-module-xrdp], [0.1], [xrdp-devel@googlegroups.com])
-# specify module-config.h so we don't collide with pulseaudio's config.h
-AC_CONFIG_HEADERS([module-config.h])
+# specify config_ac.h so we don't collide with pulseaudio's config.h
+AC_CONFIG_HEADERS([config_ac.h])
 AC_CONFIG_SRCDIR([src])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIRS([m4])


### PR DESCRIPTION
as xrdp already uses config_ac.h. To be consistent, let's use
config_ac.h rather than module-config.h. No logic changes in this PR.