### PR TITLE
Fix segfault when socket names not given via env #19

### DIFF
--- a/src/module-xrdp-sink.c
+++ b/src/module-xrdp-sink.c
@@ -322,13 +322,14 @@ static int data_send(struct userdata *u, pa_memchunk *chunk) {
             pa_log_debug("Could not obtain sink_socket from environment.");
             /* usually it doesn't reach here. if the socket name is not given
                via environment variable, use hardcoded name as fallback */
-            snprintf(sink_socket, bytes, "xrdp_chansrv_audio_out_socket_%d", u->display_num);
+            snprintf(s.sun_path, bytes,
+                    "%s/xrdp_chansrv_audio_out_socket_%d", socket_dir, u->display_num);
         }
         else
         {
             pa_log_debug("Obtained sink_socket from environment.");
+            snprintf(s.sun_path, bytes, "%s/%s", socket_dir, sink_socket);
         }
-        snprintf(s.sun_path, bytes, "%s/%s", socket_dir, sink_socket);
         pa_log_debug("trying to connect to %s", s.sun_path);
 
         if (connect(fd, (struct sockaddr *)&s,

--- a/src/module-xrdp-source.c
+++ b/src/module-xrdp-source.c
@@ -200,13 +200,14 @@ static int data_get(struct userdata *u, pa_memchunk *chunk) {
             pa_log("Could not obtain source_socket from environment.");
             /* usually it doesn't reach here. if the socket name is not given
                via environment variable, use hardcoded name as fallback */
-            snprintf(source_socket, bytes, "xrdp_chansrv_audio_in_socket_%d", u->display_num);
+            snprintf(s.sun_path, bytes,
+                    "%s/xrdp_chansrv_audio_in_socket_%d", socket_dir, u->display_num);
         }
         else
         {
             pa_log("Obtained sink_socket from environment.");
+            snprintf(s.sun_path, bytes, "%s/%s", socket_dir, source_socket);
         }
-        snprintf(s.sun_path, bytes, "%s/%s", socket_dir, source_socket);
         pa_log_debug("Trying to connect to %s", s.sun_path);
 
         if (connect(fd, (struct sockaddr *) &s, sizeof(struct sockaddr_un)) != 0) {


### PR DESCRIPTION
snprintf requires malloc before copying strings. I didn't do enough test the case
when socket names were not given via environment variable.