### PR TITLE
Add installation instructions for Fedora 33

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,127 @@ Finally, let's build xrdp source / sink modules. You'll have two .so files
     cd pulseaudio-module-xrdp
     ./bootstrap && ./configure PULSE_DIR=~/rpmbuild/BUILD/pulseaudio-10.0
     make
+*******************************************************************************
+*******************************************************************************
+
+## Fedora 33 Workstation
+Linux/Fedora version
+uname -a
+Linux localhost.localdomain 5.10.14-200.fc33.x86_64 #1 SMP Sun Feb 7 19:59:31 UTC 2021 x86_64 x86_64 x86_64 GNU/Linux
+
+
+*******************************************************************************
+Overview
+
+Install Fedora 33 Workstation from DVD/USB
+ -Select optional software groups
+   C Development Tools and Libraries
+   Development Tools
+   System Tools
+
+Read the following:
+ -https://github.com/neutrinolabs/xrdp/blob/devel/README.md
+   Requirements for building xrdp (only used for dependencies)
+
+ -https://github.com/neutrinolabs/pulseaudio-module-xrdp/wiki/README
+   How to install and configure pulseaudio source files
+   How to install and build xrdp modules for pulseaudio
+
+ -https://github.com/neutrinolabs/xrdp/wiki/Audio-Output-Virtual-Channel-support-in-xrdp
+   How xrdp selects pulseaudio modules (older info. did not do any of the suggestions.)
+
+Install pulseaudio source
+ -Download source
+ -Run ./configure to customize for your machine/version
+
+Install xrdp module source
+ -Download source
+ -Run ./bootstrap to pre-build compile environment
+ -Run ./configure make files
+ -Make modules
+ -Install modules in system directories
+
+Note:
+ -You cannot be logged in from a GUI session (on the hardware console) and xrdp at the same time.
+
+ 
+*******************************************************************************
+Installation steps from neutrino labs pulseaudio-module-xrdp readme.md file
+ -Changing 11.1 in example to 14.0 for Fedora 33 Workstation
+ -Adding additional steps for Fedora 33 Workstation
+
+# sudo -s  (home-dir is now /root)
+
+Add the following packages:
+ (from https://github.com/neutrinolabs/xrdp/blob/devel/README.md)
+ dnf install -y tigervnc-server openssl-devel pam-devel
+ dnf install -y libX11-devel libXfixes-devel libXrandr-devel
+
+ (from many attempts at ./configure)
+ dnf install -y libjpeg-devel fuse-devel perl-libxml-perl libtool-ltdl-devel
+ dnf install -y libcap-devel libsndfile-devel libgudev-devel
+ dnf install -y dbus-devel dbus-doc.noarch dbus-tests
+ dnf install -y speex-devel speex-tools speexdsp-devel
+ dnf install -y systemd-devel systemd-tests
+ dnf install -y sbc-devel
+ dnf install -y pulseaudio-libs-devel
+
+
+*******************************************************************************
+Find pulseaudio version
+# pulseaudio --version
+pulseaudio 14.0-rebootstrapped
+
+Check if xrdp modules are already installed
+# pulseaudio --dump-modules
+  note: no xrdp modules were listed on my system
+
+
+*******************************************************************************
+Retrieve and configure the pulseaudio source-version that matches your installed-version
+see the (extensive) list source-versions at https://freedesktop.org/software/pulseaudio/releases
+#
+# wget https://freedesktop.org/software/pulseaudio/releases/pulseaudio-14.0.tar.xz
+# tar xf pulseaudio-14.0.tar.xz
+# cd pulseaudio-14.0
+# ./configure
+# cd ..
+
+
+*******************************************************************************
+Retrieve, configure, and compile the source for the xrdp pulseaudio module.
+Note: use a fully-qualified path name for ./configure
+#
+# git clone https://github.com/neutrinolabs/pulseaudio-module-xrdp.git
+# cd pulseaudio-module-xrdp
+# ./bootstrap
+# ./configure PULSE_DIR='/root/pulseaudio-14.0'
+# make
+# make install
+
+
+*******************************************************************************
+Verify modules are installed
+# ls $(pkg-config --variable=modlibexecdir libpulse)
+...
+module-xrdp-sink.la		module-xrdp-sink.so		module-xrdp-source.la		module-xrdp-source.so
+
+Verify pulseaudio can use the xrdp modules.
+# pulseaudio --dump-modules
+module-xrdp-sink                        xrdp sink
+module-xrdp-source                      xrdp source
+
+Verify Fedora can see xrdp sink/source as audio options
+ -Close any remote or console sessions to your host
+ -Open a new xrdp session to your host
+ -Click:
+   Activities -> Show Applications -> Settings -> Sound
+   Output Device should be "xrdp sink"
+   Test button opens a dialog with "Left" and "Right" tests
+   Clicking on "Left" and "Right" should make sound from your corresponding speaker
+*******************************************************************************
+*******************************************************************************
+
 
 ## Other distro
 


### PR DESCRIPTION
Newer Fedora versions have very different package structures, and some CLI commands, from the currently documented  RHEL/Centos releases.