### PR TITLE
Module load and unload support

### DIFF
--- a/src/module-xrdp-sink.c
+++ b/src/module-xrdp-sink.c
@@ -578,6 +578,12 @@ void pa__done(pa_module*m) {
         pa_rtpoll_free(u->rtpoll);
     }
 
+    if (u->fd >= 0)
+    {
+        close(u->fd);
+        u->fd = -1;
+    }
+
     pa_xfree(u->sink_socket);
     pa_xfree(u);
 }

--- a/src/module-xrdp-sink.c
+++ b/src/module-xrdp-sink.c
@@ -88,6 +88,7 @@ PA_MODULE_USAGE(
 #define DEFAULT_SINK_NAME "xrdp-sink"
 #define BLOCK_USEC 30000
 //#define BLOCK_USEC (PA_USEC_PER_SEC * 2)
+#define UNUSED_VAR(x) ((void) (x))
 
 /* support for the set_state_in_io_thread callback was added in 11.99.1 */
 #if defined(PA_CHECK_VERSION) && PA_CHECK_VERSION(11, 99, 1)
@@ -186,6 +187,8 @@ static int sink_set_state_in_io_thread_cb(pa_sink *s,
                                           pa_suspend_cause_t new_suspend_cause)
 {
     struct userdata *u;
+
+    UNUSED_VAR(new_suspend_cause);
 
     pa_assert(s);
     pa_assert_se(u = s->userdata);

--- a/src/module-xrdp-source.c
+++ b/src/module-xrdp-source.c
@@ -526,6 +526,12 @@ void pa__done(pa_module*m) {
     if (u->rtpoll)
         pa_rtpoll_free(u->rtpoll);
 
+    if (u->fd >= 0)
+    {
+        close(u->fd);
+        u->fd = -1;
+    }
+
     pa_xfree(u->source_socket);
     pa_xfree(u);
 }


### PR DESCRIPTION
See neutrinolabs/xrdp#1910

This PR makes the following changes to the pulseaudio modules:-

- The first commit allows the modules to be configured via parameters instead of environment variables. This is to simplify using them on systems using `systemd --user`
- The first commit makes sure file descriptors are closed before the modules are unloaded. Without this, `pulseaudio` leaks file descriptors, and `chansrv` does not re-listen on the audio sockets.
- The third commit adds support for sink rewinds (needed for a buffer underrun), and the pulseaudio `set_state_in_io_thread` callback, for versions of pulseaudio that support it.

With these changes, the following script can be used to configure pulseaudio in an xrdp session using `systemctl --user`

```sh
#!/bin/sh

if [ -z "$XRDP_SOCKET_PATH" -o \
     -z "$XRDP_PULSE_SINK_SOCKET" -o \
     -z "$XRDP_PULSE_SOURCE_SOCKET" ]; then
    echo "** This does not appear to be an xrdp session" >&1
    false
else
    # Remove legacy environment variable if set
    systemctl --user unset-environment PA_SCRIPT || :

    # Unload modules
    pacmd unload-module module-xrdp-sink >/dev/null 2>&1
    pacmd unload-module module-xrdp-source >/dev/null 2>&1

    # Reload modules
    pacmd load-module module-xrdp-sink \
	xrdp_socket_path=$XRDP_SOCKET_PATH \
	xrdp_pulse_sink_socket=$XRDP_PULSE_SINK_SOCKET && \
    \
    pacmd load-module module-xrdp-source \
	xrdp_socket_path=$XRDP_SOCKET_PATH \
	xrdp_pulse_source_socket=$XRDP_PULSE_SOURCE_SOCKET
fi

exit $?
```

I've tested the module with these platforms:-

|Platform |  pulseaudio version | systemd --user ? | Comments |
|:---|:---|:---|:---|
| Ubuntu 18.04 | 11.1 | No | Hard to configure as xrdp is old |
| Ubuntu 20.04 | 13.99.1 | Yes | |
| CentOS 7 | 10.0 | No | |
| CentOS 8 | 14.0 | Yes | Hard to build - [wiki page added](/neutrinolabs/pulseaudio-module-xrdp/wiki/Build-on-CentOS-8.x) |

Clearly we've got more work to do to support `systemd --user` properly, but this is a start.