### PR TITLE
Add install files to the build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = src
+SUBDIRS = src instfiles
 EXTRA_DIST = bootstrap.sh

--- a/configure.ac
+++ b/configure.ac
@@ -80,5 +80,6 @@ AC_TYPE_UINT32_T
 AC_CHECK_FUNCS([memset socket])
 
 AC_CONFIG_FILES([Makefile
-                 src/Makefile])
+                 src/Makefile
+                 instfiles/Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,9 @@ PA_LIBDIR=`$PKG_CONFIG --variable=libdir libpulse`
 PA_MODDIR=`$PKG_CONFIG --variable=modlibexecdir libpulse`
 PA_PREFIX=`$PKG_CONFIG --variable=prefix libpulse`
 
+# Default system-wide autostart directory from XDG autostart specification
+m4_define([XDG_AUTOSTART_DIR], /etc/xdg/autostart)
+
 AC_SUBST([PA_MAJOR], [pa_major])
 AC_SUBST([PA_MINOR], [pa_minor])
 AC_SUBST([PA_MAJORMINOR], [pa_major].[pa_minor])
@@ -67,6 +70,13 @@ AC_ARG_WITH(
         [Directory where to install the modules to (defaults to `pkg-config --variable=modlibexecdir libpulse`)])],
     [modlibexecdir=$withval], [modlibexecdir="${PA_MODDIR}"])
 AC_SUBST(modlibexecdir)
+
+AC_ARG_WITH(
+    [xdgautostart-dir],
+    [AS_HELP_STRING([--with-xdgautostart-dir],
+                    Directory to install the desktop file (defaults to XDG_AUTOSTART_DIR))],
+    [xdgautostartdir=$withval], [xdgautostartdir=XDG_AUTOSTART_DIR])
+AC_SUBST(xdgautostartdir)
 
 # Checks for header files.
 AC_CHECK_HEADERS([fcntl.h limits.h netinet/in.h stdlib.h string.h sys/ioctl.h sys/socket.h unistd.h])

--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -1,0 +1,33 @@
+EXTRA_DIST = \
+   load_pa_modules.sh \
+   pulseaudio-xrdp.desktop.in
+
+#
+# substitute directories in service file
+#
+CLEANFILES= \
+   pulseaudio-xrdp.desktop
+
+SUBST_VARS = sed \
+   -e 's|@pkglibexecdir[@]|$(pkglibexecdir)|g'
+
+subst_verbose = $(subst_verbose_@AM_V@)
+subst_verbose_ = $(subst_verbose_@AM_DEFAULT_V@)
+subst_verbose_0 = @echo "  SUBST    $@";
+
+SUFFIXES = .in
+.in:
+	$(subst_verbose)$(SUBST_VARS) $< > $@
+
+#
+# files for all platforms
+#
+
+# Don't use sysconfdir for this one as it won't work!
+xdgautostartdir=/etc/xdg/autostart
+
+xdgautostart_DATA = \
+  pulseaudio-xrdp.desktop
+
+pkglibexec_SCRIPTS = \
+  load_pa_modules.sh

--- a/instfiles/Makefile.am
+++ b/instfiles/Makefile.am
@@ -22,10 +22,6 @@ SUFFIXES = .in
 #
 # files for all platforms
 #
-
-# Don't use sysconfdir for this one as it won't work!
-xdgautostartdir=/etc/xdg/autostart
-
 xdgautostart_DATA = \
   pulseaudio-xrdp.desktop
 

--- a/instfiles/load_pa_modules.sh
+++ b/instfiles/load_pa_modules.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+PACTL=/usr/bin/pactl
+
+if [ -n "$XRDP_SESSION" -a -n "$XRDP_SOCKET_PATH" ]; then
+    # These values are not present on xrdp versions before v0.9.8
+    if [ -z "$XRDP_PULSE_SINK_SOCKET" -o \
+         -z "$XRDP_PULSE_SOURCE_SOCKET" ]; then
+        displaynum=${DISPLAY##*:}
+        displaynum=${displaynum%.*}
+        XRDP_PULSE_SINK_SOCKET=xrdp_chansrv_audio_out_socket_$displaynum
+        XRDP_PULSE_SOURCE_SOCKET=xrdp_chansrv_audio_in_socket_$displaynum
+    fi
+
+    # Don't check for the presence of the sockets, as if the modules
+    # are loaded they won't be there
+
+    # Unload modules
+    $PACTL unload-module module-xrdp-sink >/dev/null 2>&1
+    $PACTL unload-module module-xrdp-source >/dev/null 2>&1
+
+    # Reload modules
+    $PACTL load-module module-xrdp-sink \
+        xrdp_socket_path=$XRDP_SOCKET_PATH \
+        xrdp_pulse_sink_socket=$XRDP_PULSE_SINK_SOCKET && \
+    \
+    $PACTL load-module module-xrdp-source \
+        xrdp_socket_path=$XRDP_SOCKET_PATH \
+        xrdp_pulse_source_socket=$XRDP_PULSE_SOURCE_SOCKET
+fi
+
+exit $?

--- a/instfiles/pulseaudio-xrdp.desktop.in
+++ b/instfiles/pulseaudio-xrdp.desktop.in
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Name=PulseAudio xrdp modules
+Comment=Load PulseAudio Modules for xrdp
+Exec=@pkglibexecdir@/load_pa_modules.sh
+Terminal=false
+Type=Application
+Categories=
+GenericName=


### PR DESCRIPTION
Adds installation files to the build.

`make install` now also creates the following files:-

- /usr/libexec/pulseaudio-module-xrdp/load_pa_modules.sh which dynamically loads the xrdp pulseaudio modules
- /etc/xdg/autostart/pulseaudio-xrdp.desktop which calls to the above for any desktop which supports the [XDG autostart](https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html) specification.

This PR is dependent on #59 

This method of loading pulseaudio drivers is compatible with existing systems, and removes the need for PA_SCRIPT to be set in `/etc/xrdp/sesman.ini` for all systems.