### PR TITLE
Add support for Meson build system used by Pulseaudio 15

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,16 @@ fi
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
+dnl ------------------------------------------------------------------
+dnl FIND_CONFIG_H(TOP_DIRECTORY)
+dnl Find the config.h file under TOP_DIRECTORY
+dnl
+dnl Outputs the enclosing directory. Only the first match is returned.
+dnl ------------------------------------------------------------------
+m4_define([FIND_CONFIG_H],
+          [find $1 -type f -maxdepth 3 -type f -name config.h | \
+           sed -e 's#/config.h##' -e '2,$d'])
+
 # get system's pulseaudio version
 m4_define([pa_major], [`$PKG_CONFIG --modversion libpulse | cut -d. -f1`])
 m4_define([pa_minor], [`$PKG_CONFIG --modversion libpulse | cut -d. -f2`])
@@ -52,6 +62,7 @@ PKG_CHECK_MODULES([LIBPULSE], [libpulse])
 
 m4_define([PULSE_MSG], [PULSE_DIR not specified. Follow the instructions in README.md.])
 
+# Check PULSE_DIR is specified
 AC_ARG_VAR([PULSE_DIR], [pulseaudio source code directory])
 AS_IF([test x"$PULSE_DIR" == x""],
 cat <<__MSG__
@@ -59,6 +70,31 @@ m4_text_box([PULSE_MSG])
 __MSG__
 AC_MSG_ERROR([PULSE_DIR not specified])
 )
+
+# Does PULSE_DIR appear to be valid?
+AS_IF([test -e "$PULSE_DIR/src/pulsecore/macro.h"],,
+      AC_MSG_WARN([PULSE_DIR may not be valid - can't find expected file]))
+
+# Look for config.h, using PULSE_CONFIG_DIR if specified
+AC_ARG_VAR([PULSE_CONFIG_DIR], [pulseaudio config.h source code directory (optional)])
+AS_IF([test x"$PULSE_CONFIG_DIR" == x""],
+      AC_MSG_NOTICE([PULSE_CONFIG_DIR not defined])
+      AC_MSG_CHECKING([Searching for config.h under PULSE_DIR])
+      PULSE_CONFIG_DIR="`FIND_CONFIG_H(\"$PULSE_DIR\")`"
+      [AS_IF([test -e "$PULSE_CONFIG_DIR/config.h" ],
+          AC_MSG_RESULT([$PULSE_CONFIG_DIR/config.h])
+          ,
+          AC_MSG_RESULT([no])
+          AC_MSG_ERROR([Can't find config.h under PULSE_DIR. Define PULSE_CONFIG_DIR?]))]
+      ,
+      AC_MSG_NOTICE([PULSE_CONFIG_DIR is defined])
+      AC_MSG_CHECKING([Looking for config.h in PULSE_CONFIG_DIR])
+      [AS_IF([test -e "$PULSE_CONFIG_DIR/config.h"],
+          AC_MSG_RESULT([$PULSE_CONFIG_DIR/config.h])
+          ,
+          AC_MSG_RESULT([no])
+          AC_MSG_ERROR([Can't find config.h in PULSE_CONFIG_DIR.]))])
+
 
 # use the prefix as same as pulseaudio
 AC_PREFIX_PROGRAM(pulseaudio)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,6 @@
 AM_CFLAGS = -O2   \
             -fPIC \
-            -I $(PULSE_DIR)      \
+            -I $(PULSE_CONFIG_DIR)      \
             -I $(PULSE_DIR)/src  \
             $(XRDP_CFLAGS)
 


### PR DESCRIPTION
Fixes #58 

Pulseaudio 15 uses the Meson build system rather than autotools for configuration. As a result, the pulseaudio `config.h` file is not located in `$PULSE_DIR`

There is no fixed location for `config.h` when Meson is used - it depends on how `meson build` is actually called.

In the course of investigating #58, the following was determined:-
- For a Fedora 35 RPM build using `rpmbuild` / `mock`, `config.h` is in `$PULSE_DIR/redhat-linux-build`
- For a basic invocation of `meson build` on the command line, `config.h` is in `$PULSE_DIR/build`
- For Manjaro using `PKGBUILD`, `config.h` is in `$PULSE_DIR/../build/`

This PR implements the following logic:-
- If `PULSE_CONFIG_DIR` is not  defined, `./configure` searches for `config.h` in `$PULSE_DIR` down a maximum 3 levels.
- If `PULSE_CONFIG_DIR` is defined `./configure` expects `config.h` to be in the directory `$PULSE_CONFIG_DIR/`

The search is adequate to support existing autotools functionality, F35 and a basic call to `meson build`. For these distros the build interface is the same.
If the search does not locate `config.h` (i.e. Manjaro/Arch and probably others), the location can be specified explicitly.

Additionally a warning is now generated if PULSE_DIR is defined but does not appear to be correct.