### PR TITLE
  Update github actions to address warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,14 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Set steps.os.outputs.image to the specific OS (e.g. 'ubuntu20')
-      # see https://github.com/actions/cache/issues/543
       - name: Get operating system name and version.
         id: os
-        run: echo "::set-output name=image::$ImageOS"
+        run: echo "image=$ImageOS" >>$GITHUB_OUTPUT
         shell: bash
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache pulseaudio source
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-pulseaudio-src
         with:
@@ -44,16 +43,16 @@ jobs:
     steps:
       - name: Get operating system name and version.
         id: os
-        run: echo "::set-output name=image::$ImageOS"
+        run: echo "image=$ImageOS" >>$GITHUB_OUTPUT
         shell: bash
       - name: Fetch pulseaudio sources
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-pulseaudio-src
         with:
           path: ~/pulseaudio.src
           key: ${{ steps.os.outputs.image }}-build-${{ env.cache-name }}
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo apt-get update
       - run: sudo apt-get -yq install build-essential libpulse-dev
       - run: ./bootstrap

--- a/scripts/install_pulseaudio_sources_apt.sh
+++ b/scripts/install_pulseaudio_sources_apt.sh
@@ -98,6 +98,15 @@ if [ ! -d "$PULSE_DIR" ]; then
 
     sudo apt-get update
 
+    # For the CI build on 22.04, it was noted that an incompatible
+    # libunwind development package was installed.
+    if [ -f /usr/include/libunwind/libunwind.h ]; then
+        pkg=`dpkg -S /usr/include/libunwind/libunwind.h | sed -e 's/: .*//'`
+        if [ -n "$pkg" -a "$pkg" != libunwind-dev ]; then
+            echo "- Removing package $pkg"
+            sudo apt-get remove "$pkg"
+        fi
+    fi
     sudo apt-get build-dep -y pulseaudio
     # Install any missing dependencies for this software release
     case "$RELEASE" in


### PR DESCRIPTION
Update the github actions yaml file to address warnings.

Also, after testing on CI using `ubuntu-22.04` add some code to `scripts/install_pulseaudio_sources_apt.sh` to remove an incompatible development package if it's installed. This will be required when `ubuntu-latest` is switched to `ubuntu-22.04`.