### PR TITLE
scripts: further update scripts to work better with derivative distros.

### DIFF
--- a/scripts/install_pulseaudio_sources_apt.sh
+++ b/scripts/install_pulseaudio_sources_apt.sh
@@ -80,7 +80,7 @@ if [ ! -d "$PULSE_DIR" ]; then
     esac
 
     # Make sure sources are available
-    for srclst in $(ls /etc/apt/*.list /etc/apt/sources.list.d/*.list 2> /dev/null); do
+    for srclst in $(find /etc/apt/ /etc/apt/sources.list.d -maxdepth 1 -type f -name '*.list'); do
 	if ! grep -q '^ *deb-src' $srclst; then
             echo "- Adding source repositories" >&2
             cp $srclst /tmp/sources.list
@@ -96,7 +96,7 @@ if [ ! -d "$PULSE_DIR" ]; then
 		| sudo tee -a $srclst >/dev/null
             rm /tmp/sources.list
 	fi
-	cat $srclst | grep $codename | sudo tee $srclst
+	sudo sed -i "/$codename/!d" $srclst
     done
 
     sudo apt-get update

--- a/scripts/install_pulseaudio_sources_apt.sh
+++ b/scripts/install_pulseaudio_sources_apt.sh
@@ -97,7 +97,10 @@ if [ ! -d "$PULSE_DIR" ]; then
             rm /tmp/sources.list
 	fi
 	sudo sed -i "/$codename/!d" $srclst
+	cat $srclst >> /tmp/combined_sources.list
+	sudo rm $srclst
     done
+    cat /tmp/combined_sources.list | sort | uniq | sudo tee /etc/apt/sources.list > /dev/null
 
     sudo apt-get update
 

--- a/scripts/install_pulseaudio_sources_apt.sh
+++ b/scripts/install_pulseaudio_sources_apt.sh
@@ -79,32 +79,33 @@ if [ ! -d "$PULSE_DIR" ]; then
             ;;
     esac
 
-    # Make sure sources are available
-    for srclst in $(find /etc/apt/ /etc/apt/sources.list.d -maxdepth 1 -type f -name '*.list'); do
-	if ! grep -q '^ *deb-src' $srclst; then
-            echo "- Adding source repositories" >&2
-            cp $srclst /tmp/sources.list
-            while read type url suite rest; do
-		if [ "$type" = deb ]; then
-                    case "$suite" in
-			$codename | $codename-updates | $codename-security)
-                            echo "deb-src $url $suite $rest"
-                            ;;
-                    esac
-		fi
-            done </tmp/sources.list \
-		| sudo tee -a $srclst >/dev/null
-            rm /tmp/sources.list
-	fi
-	# remove references to other distro's package sources; needed when running the wrapper in a
-	# derivative-distro (like Linux Mint 21.2 'victoria') with --suite option (--suite=jammy).
-	sudo sed -i "/$codename/!d" $srclst
-	cat $srclst >> /tmp/combined_sources.list # prepare a combined sources.list file
-	sudo rm $srclst # remove the *.list file as we will use the combined .list file
-    done
-    # remove duplicates from the combined source.list in order to prevent apt warnings/errors;
-    # this is useful in cases where the user has already configured source code repositories.
-    cat /tmp/combined_sources.list | sort | uniq | sudo tee /etc/apt/sources.list > /dev/null
+    # Scan the source repositories. Add sources for all repositories
+    # in this suite.
+    # Ignore other suites. This is needed when running the wrapper in a
+    # derivative-distro (like Linux Mint 21.2 'victoria') with --suite
+    # option (--suite=jammy).
+    echo "- Adding source repositories" >&2
+    SRCLIST=$(find /etc/apt/ /etc/apt/sources.list.d -maxdepth 1 -type f -name '*.list')
+    for srclst in $SRCLIST; do
+        while read type url suite rest; do
+            case "$suite" in
+                $codename | $codename-updates | $codename-security)
+                    if [ "$type" = deb ]; then
+                        echo "deb $url $suite $rest"
+                        echo "deb-src $url $suite $rest"
+                    fi
+                    ;;
+            esac
+        done <$srclst
+    done >/tmp/combined_sources.list
+
+    sudo rm $SRCLIST ;# Remove source respositories
+
+    # remove duplicates from the combined source.list in order to prevent
+    # apt warnings/errors; this is useful in cases where the user has
+    # already configured source code repositories.
+    sort -u < /tmp/combined_sources.list | \
+        sudo tee /etc/apt/sources.list > /dev/null
 
     sudo apt-get update
 

--- a/scripts/install_pulseaudio_sources_apt.sh
+++ b/scripts/install_pulseaudio_sources_apt.sh
@@ -96,10 +96,14 @@ if [ ! -d "$PULSE_DIR" ]; then
 		| sudo tee -a $srclst >/dev/null
             rm /tmp/sources.list
 	fi
+	# remove references to other distro's package sources; needed when running the wrapper in a
+	# derivative-distro (like Linux Mint 21.2 'victoria') with --suite option (--suite=jammy).
 	sudo sed -i "/$codename/!d" $srclst
-	cat $srclst >> /tmp/combined_sources.list
-	sudo rm $srclst
+	cat $srclst >> /tmp/combined_sources.list # prepare a combined sources.list file
+	sudo rm $srclst # remove the *.list file as we will use the combined .list file
     done
+    # remove duplicates from the combined source.list in order to prevent apt warnings/errors;
+    # this is useful in cases where the user has already configured source code repositories.
     cat /tmp/combined_sources.list | sort | uniq | sudo tee /etc/apt/sources.list > /dev/null
 
     sudo apt-get update

--- a/scripts/install_pulseaudio_sources_apt_wrapper.sh
+++ b/scripts/install_pulseaudio_sources_apt_wrapper.sh
@@ -216,7 +216,7 @@ echo "- Creating schroot config file $schroot_conf"
 } | sudo tee $schroot_conf >/dev/null || exit $?
 
 # Copy some files to the build root
-for file in /etc/apt/sources.list; do
+for file in $(ls /etc/apt/*.list /etc/apt/sources.list.d/*.list 2> /dev/null); do
     echo "- Copying $file to the root"
     sudo install -m 0644 $file $BUILDROOT/$file || exit $?
 done

--- a/scripts/install_pulseaudio_sources_apt_wrapper.sh
+++ b/scripts/install_pulseaudio_sources_apt_wrapper.sh
@@ -216,7 +216,7 @@ echo "- Creating schroot config file $schroot_conf"
 } | sudo tee $schroot_conf >/dev/null || exit $?
 
 # Copy some files to the build root
-for file in $(ls /etc/apt/*.list /etc/apt/sources.list.d/*.list 2> /dev/null); do
+for file in $(find /etc/apt/ /etc/apt/sources.list.d -maxdepth 1 -type f -name '*.list'); do
     echo "- Copying $file to the root"
     sudo install -m 0644 $file $BUILDROOT/$file || exit $?
 done


### PR DESCRIPTION
- copy *.list files from /etc/apt/sources.list.d into the chroot
The scripts were not working on Linux Mint 21.2 because it keeps it's sources list inside `/etc/apt/sources.list.d` instead of the usual place. This change makes it work. Also tested on Ubuntu 22.04 and Debian 12 to make sure nothing breaks - it doesn't.
- inside the chroot, filter out references to the derivative distro's package sources.
Otherwise `apt-get update` fails because of lack of valid signature.

