### PR TITLE
update apt before installing sudo and lsb_release

### DIFF
--- a/scripts/install_pulseaudio_sources_apt_wrapper.sh
+++ b/scripts/install_pulseaudio_sources_apt_wrapper.sh
@@ -114,6 +114,7 @@ RunWrappedScript()
     schroot="schroot -c pa-build-$USER -d /build"
 
     # Install extra dependencies
+    $schroot -u root -- apt-get update
     $schroot -u root -- apt-get install -y $WRAPPED_SCRIPT_DEPS
 
     # Allow normal user to sudo without a password


### PR DESCRIPTION
The script provided fails because it cannot find the packages sudo and lsb_release. This fixes the problem.