### PR TITLE
Specify uid when creating the user via useradd

### DIFF
--- a/scripts/install_pulseaudio_sources_apt_wrapper.sh
+++ b/scripts/install_pulseaudio_sources_apt_wrapper.sh
@@ -122,7 +122,7 @@ RunWrappedScript()
 
     # Allow normal user to sudo without a password. We may need to add the
     # normal user, as it probably isn't created by debootstrap
-    $schroot -u root -- useradd -m $USER || :
+    $schroot -u root -- useradd -m $USER -u $(id -u) || :
     $schroot -u root -- \
         /bin/sh -c "echo '$USER ALL=(ALL) NOPASSWD:ALL'>/etc/sudoers.d/nopasswd-$USER"
     $schroot -u root -- chmod 400 /etc/sudoers.d/nopasswd-$USER


### PR DESCRIPTION
On my ubuntu24.04, the user created via useradd always has uid=1000. However, the uid I observed entering chroot is the same as my own uid, which is not 1000. Therefore, tools like sudo will fail because it cannot recognize what user it is.

This commit fixes the issue by forcing the uid to be the same as the outer one when creating the user via useradd.

Note that I didn't test this commit on other platforms, so I'm not sure if it would break other platforms.