### PR TITLE
CI: Upgrade to latest github action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
         id: os
         run: echo "image=$ImageOS" >>$GITHUB_OUTPUT
         shell: bash
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Cache pulseaudio source
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         env:
           cache-name: cache-pulseaudio-src
         with:
@@ -46,13 +46,13 @@ jobs:
         run: echo "image=$ImageOS" >>$GITHUB_OUTPUT
         shell: bash
       - name: Fetch pulseaudio sources
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         env:
           cache-name: cache-pulseaudio-src
         with:
           path: ~/pulseaudio.src
           key: ${{ steps.os.outputs.image }}-build-${{ env.cache-name }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: sudo apt-get update
       - run: sudo apt-get -yq install build-essential libpulse-dev libltdl-dev
       - run: ./bootstrap


### PR DESCRIPTION
This has been prompted by the following deprecation messages:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4.